### PR TITLE
Alternate Fix For Approval

### DIFF
--- a/project_share/signals.py
+++ b/project_share/signals.py
@@ -1,7 +1,8 @@
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from project_share.models import Approval
+from project_share.models import Approval, Project
+from django_teams.models import Ownership
 from django_comments_xtd.models import XtdComment
 
 @receiver(post_save, sender=Approval)
@@ -15,3 +16,10 @@ def approval_comment(sender, instance, created, **kwargs):
     if created == True:
         instance.is_public = False
         instance.save()
+		
+@receiver(post_save, sender=Ownership)
+def approval_comment(sender, instance, created, **kwargs):
+    if instance.approved == True:
+        p = Project.objects.get(pk=instance.object_id)
+        p.approved = True
+        p.save() 

--- a/project_share/signals.py
+++ b/project_share/signals.py
@@ -19,7 +19,7 @@ def approval_comment(sender, instance, created, **kwargs):
 		
 @receiver(post_save, sender=Ownership)
 def approval_comment(sender, instance, created, **kwargs):
-    if instance.approved == True:
+    if instance.content_type == ContentType.objects.get(app_label="project_share", model="project") and instance.approved == True:
         p = Project.objects.get(pk=instance.object_id)
         p.approved = True
         p.save() 

--- a/project_share/templates/django_teams/fragments/project_share/project.html
+++ b/project_share/templates/django_teams/fragments/project_share/project.html
@@ -1,0 +1,17 @@
+{% load thumbnail %}
+
+        <div class="thumbnail-long">
+            <div class="heading">
+                <h3><a href="{% url 'project-detail' pk=object.id %}">{{ object }}</a></h3>
+            </div>
+            <div class="body">
+                <div class="image">
+                      {% thumbnail object.screenshot.f "400x400" as im %}
+                      <a href="{% url 'project-detail' pk=object.id %}"><img class="img-polaroid" src="{{ im.url }}" width="{{ im.width }}" height="{{ im.height }}"></a>
+                      {% endthumbnail %}
+                </div>
+                <div class="description">
+                    <p>{{ object.description }}</p>
+                </div>
+            </div>
+        </div>


### PR DESCRIPTION
Added a hook to the Ownership table that updates the Project table.

Some day we all need to have a talk about why we made libraries that don't merge back to the original teams, but which we don't want to be part of the project.