### PR TITLE
Added a api/team request

### DIFF
--- a/project_share/tests/test_api.py
+++ b/project_share/tests/test_api.py
@@ -241,7 +241,7 @@ class ProjectTests(LiveServerTestCase):
         Verify that we can get a list of projects for this user using the REST API
         """
         from django.test import Client
-        url = reverse(r'^api/team') + "?owner=1"
+        url = reverse(r'^api/team') + "?user=1"
         # This doesn't work with the built-in client
         # !! This was fixed in the edge version as of 2014-04-21
         # !! Edge version of Django Rest Framework :)

--- a/project_share/tests/test_api.py
+++ b/project_share/tests/test_api.py
@@ -235,6 +235,22 @@ class ProjectTests(LiveServerTestCase):
         self_url = 1
         for project in response.data:
           self.assertEqual(project['owner'], self_url)
+		  
+    def test_get_teams(self):
+        """
+        Verify that we can get a list of projects for this user using the REST API
+        """
+        from django.test import Client
+        url = reverse(r'^api/team') + "?owner=1"
+        # This doesn't work with the built-in client
+        # !! This was fixed in the edge version as of 2014-04-21
+        # !! Edge version of Django Rest Framework :)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self_url = 1
+        for project in response.data:
+          self.assertEqual(project['owner'], self_url)
 
     def test_saving_published_project_creates_unpublished_project(self):
         """

--- a/project_share/tests/test_api.py
+++ b/project_share/tests/test_api.py
@@ -241,7 +241,7 @@ class ProjectTests(LiveServerTestCase):
         Verify that we can get a list of projects for this user using the REST API
         """
         from django.test import Client
-        url = reverse(r'^api/team') + "?user=1"
+        url = reverse('api-teams-list') + "?user=1"
         # This doesn't work with the built-in client
         # !! This was fixed in the edge version as of 2014-04-21
         # !! Edge version of Django Rest Framework :)
@@ -249,8 +249,8 @@ class ProjectTests(LiveServerTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self_url = 1
-        for project in response.data:
-          self.assertEqual(project['owner'], self_url)
+        for team in response.data:
+          self.assertEqual(team['user'], self_url)
 
     def test_saving_published_project_creates_unpublished_project(self):
         """

--- a/rpi_csdt_community/serializers.py
+++ b/rpi_csdt_community/serializers.py
@@ -57,8 +57,8 @@ class TeamSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = TeamStatus
-        fields = ('id', 'team_name', 'team')
-        read_only_fields = ('id', 'team_name', 'team')
+        fields = ('id', 'role', 'team_name', 'team')
+        read_only_fields = ('id', 'role', 'team_name', 'team')
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/rpi_csdt_community/serializers.py
+++ b/rpi_csdt_community/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from project_share.models import ApplicationDemo, Project, Goal, Application
 from project_share.models import ApplicationTheme, ApplicationCategory
+from django_teams.models import TeamStatus
 
 try:
     from django.contrib.auth import get_user_model
@@ -42,6 +43,23 @@ class ProjectSerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'description', 'approved', 'application', 'owner', 'project_url', 'screenshot_url', 'project', 'screenshot',)
         write_only_fields = ('project', 'screenshot',)
         read_only_fields = ('id', 'approved','owner', 'project_url', 'screenshot_url',)
+
+class TeamSerializer(serializers.ModelSerializer):
+    team_name = serializers.StringRelatedField(source='team', read_only=True)
+	
+    def __init__(self, *args, **kwargs):
+        super(TeamSerializer, self).__init__(*args, **kwargs)
+        self.request = kwargs['context']['request']
+
+    def create(self, validated_data):
+        validated_data['owner'] = self.request.user
+        return super(TeamSerializer, self).create(validated_data)
+
+    class Meta:
+        model = TeamStatus
+        fields = ('id', 'team_name', 'team')
+        read_only_fields = ('id', 'team_name', 'team')
+
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:

--- a/rpi_csdt_community/urls.py
+++ b/rpi_csdt_community/urls.py
@@ -6,11 +6,12 @@ from django.conf import settings
 from django.contrib import admin
 admin.autodiscover()
 
-from rpi_csdt_community.viewsets import ProjectViewSet, DemosViewSet, GoalViewSet, ApplicationViewSet, FileUploadView, CurrentUserView
+from rpi_csdt_community.viewsets import ProjectViewSet, DemosViewSet, GoalViewSet, ApplicationViewSet, FileUploadView, CurrentUserView, TeamViewSet
 from rpi_csdt_community.viewsets import ApplicationThemeViewSet, ApplicationCategoryViewSet
 from rest_framework import routers
 router = routers.DefaultRouter()
 router.register(r'projects', ProjectViewSet, base_name='api-projects')
+router.register(r'team', TeamViewSet, base_name='api-teams')
 router.register(r'demos', DemosViewSet, base_name='api-demos')
 router.register(r'goals', GoalViewSet, base_name='api-goals')
 router.register(r'application', ApplicationViewSet, base_name='api-modules')

--- a/rpi_csdt_community/viewsets.py
+++ b/rpi_csdt_community/viewsets.py
@@ -50,8 +50,9 @@ class TeamViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
 		queryset = self.model.objects.select_related()
-		user = self.request.QUERY_PARAMS.get('owner', None)
-		queryset = queryset.filter(user_id=get_object_or_404(ExtendedUser, pk=user))
+		user = self.request.QUERY_PARAMS.get('user', None)
+		queryset = queryset.filter(user=get_object_or_404(ExtendedUser, pk=user))
+		queryset = queryset.filter(role='10') | queryset.filter(role='20')
 		return queryset
 	
 class DemosViewSet(viewsets.ReadOnlyModelViewSet):

--- a/rpi_csdt_community/viewsets.py
+++ b/rpi_csdt_community/viewsets.py
@@ -5,6 +5,7 @@ from django.shortcuts import get_object_or_404
 
 from project_share.models import Project, ApplicationDemo, ExtendedUser, FileUpload, Goal, Application
 from project_share.models import ApplicationTheme, ApplicationCategory
+from django_teams.models import TeamStatus, Team
 from rpi_csdt_community.serializers import *
 from django.conf import settings
 import os
@@ -43,6 +44,16 @@ class ProjectViewSet(viewsets.ModelViewSet):
           queryset = queryset.filter(owner=get_object_or_404(ExtendedUser, pk=user))
         return queryset
 
+class TeamViewSet(viewsets.ModelViewSet):
+    model = TeamStatus
+    serializer_class = TeamSerializer
+
+    def get_queryset(self):
+		queryset = self.model.objects.select_related()
+		user = self.request.QUERY_PARAMS.get('owner', None)
+		queryset = queryset.filter(user_id=get_object_or_404(ExtendedUser, pk=user))
+		return queryset
+	
 class DemosViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ApplicationDemo.objects.all()
     serializer_class = DemoSerializer


### PR DESCRIPTION
This is meant to allow C-Snap to query which classrooms a user is a
member of. To do this you send api/team/?owner={number} and then it
returns name and team number.